### PR TITLE
214 make file downloads more robust

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "embody-serial"
-version = "1.0.12"
+version = "1.0.13"
 description = "Communicate with the embody device over a serial port"
 authors = ["Aidee Health AS <hello@aidee.io>"]
 license = "MIT"

--- a/src/embodyserial/__main__.py
+++ b/src/embodyserial/__main__.py
@@ -10,4 +10,7 @@ def main():
 
 
 if __name__ == "__main__":
-    sys.exit(main())
+    try:
+        sys.exit(main())
+    except KeyboardInterrupt:
+        sys.exit(1)

--- a/src/embodyserial/embodyserial.py
+++ b/src/embodyserial/embodyserial.py
@@ -201,7 +201,7 @@ class _MessageSender(ResponseMessageListener):
         self.__response_event.set()
 
     def send_message(self, msg: codec.Message) -> None:
-        self.__send_async(msg, False)
+        self.__send_async(msg)
 
     def send_message_and_wait_for_response(
         self, msg: codec.Message, timeout: Optional[int] = 30

--- a/src/embodyserial/embodyserial.py
+++ b/src/embodyserial/embodyserial.py
@@ -122,9 +122,6 @@ class EmbodySerial(ConnectionListener, EmbodySender):
     ) -> str:
         """Download file from device and write to temporary file.
 
-        Note! Do not try to send messages to the device during file download, as this will
-        cause the download to fail.
-
         Raises:
           MissingResponseError if no response.
           CrcError if invalid crc.

--- a/src/embodyserial/embodyserial.py
+++ b/src/embodyserial/embodyserial.py
@@ -296,7 +296,6 @@ class _ReaderThread(threading.Thread):
         """Set reader in file mode and read file."""
         if hasattr(self.__serial, "timeout"):
             self.__serial.timeout = 10
-        self.__reset_file_mode()
         f = _FileDownload(
             file_size=size,
             file_timeout=timeout,
@@ -470,6 +469,8 @@ class _ReaderThread(threading.Thread):
         logging.debug(f"RECEIVE: Received header {raw_header.hex()}")
         msg_type, length = struct.unpack(">BH", raw_header)
         logging.debug(f"RECEIVE: Received msg type: {msg_type}, length: {length}")
+        if length > 20480:
+            raise ValueError(f"Message length too long: {length}")
         remaining_length = length - 3
         raw_message = raw_header
         while remaining_length > 0:

--- a/src/embodyserial/embodyserial.py
+++ b/src/embodyserial/embodyserial.py
@@ -362,6 +362,9 @@ class _ReaderThread(threading.Thread):
             except OSError:
                 logging.info("OS Error reading from socket (OSError)")
                 break
+            except ValueError:
+                logging.info("ValueError reading from socket (Probably disconnected)")
+                break
         self.alive = False
         self.__notify_connection_listeners(connected=False)
 

--- a/src/embodyserial/embodyserial.py
+++ b/src/embodyserial/embodyserial.py
@@ -187,7 +187,7 @@ class _MessageSender(ResponseMessageListener):
         )
 
     def shutdown(self) -> None:
-        self.__send_executor.shutdown(wait=False, cancel_futures=False)
+        self.__send_executor.shutdown(wait=True, cancel_futures=False)
 
     def response_message_received(self, msg: codec.Message) -> None:
         """Invoked when response message is received by Message reader.
@@ -332,13 +332,11 @@ class _ReaderThread(threading.Thread):
         self.alive = False
         if hasattr(self.__serial, "cancel_read"):
             self.__serial.cancel_read()
-        self.__message_listener_executor.shutdown(wait=False, cancel_futures=False)
+        self.__message_listener_executor.shutdown(wait=True, cancel_futures=False)
         self.__response_message_listener_executor.shutdown(
-            wait=False, cancel_futures=False
+            wait=True, cancel_futures=False
         )
-        self.__file_download_listener_executor.shutdown(
-            wait=False, cancel_futures=False
-        )
+        self.__file_download_listener_executor.shutdown(wait=True, cancel_futures=False)
         self.join(2)
 
     def run(self) -> None:

--- a/src/embodyserial/embodyserial.py
+++ b/src/embodyserial/embodyserial.py
@@ -122,6 +122,9 @@ class EmbodySerial(ConnectionListener, EmbodySender):
     ) -> str:
         """Download file from device and write to temporary file.
 
+        Note! Do not try to send messages to the device during file download, as this will
+        cause the download to fail.
+
         Raises:
           MissingResponseError if no response.
           CrcError if invalid crc.
@@ -130,10 +133,9 @@ class EmbodySerial(ConnectionListener, EmbodySender):
             return tempfile.NamedTemporaryFile(delete=False).name
         self.send_async(codec.GetFileUart(types.File(file_name)))
         # lock send to prevent sending other messages while downloading
-        with self.__sender._send_lock:
-            return self.__reader.download_file(
-                file_name, size, download_listener, timeout, delay
-            )
+        return self.__reader.download_file(
+            file_name, size, download_listener, timeout, delay
+        )
 
     @staticmethod
     def __find_serial_port() -> str:


### PR DESCRIPTION
- Prevent from sending new messages during file downloads
- Streamline buffering of file data even more by using available bytes on OS level serial socket

Changes makes downloads better, but not error proof. Have also tried with DSRDTR hardware flow control, but not respected by client. 

Buffer handling is very similar to how pyserial does it in its own thread-based implementation.

High CPU load or similar may still cause errors in file transfers. This is familiar for pyserial. 

Buffer of native RX driver may need to be tuned/increased to prevent the loss of data in all cases. However, more robust now than before. 

Consider using Windows-specific `set_read_buffer` method for increased robustness on windows without manual configuration, as described here: [PySerial Windows implementation](https://github.com/pyserial/pyserial/blob/31fa4807d73ed4eb9891a88a15817b439c4eea2d/serial/serialwin32.py#L418)

Resources:
[https://stackoverflow.com/questions/12302155/how-to-expand-input-buffer-size-of-pyserial](https://www.researchgate.net/deref/https%3A%2F%2Fstackoverflow.com%2Fquestions%2F12302155%2Fhow-to-expand-input-buffer-size-of-pyserial)
[https://stackoverflow.com/questions/10815811/linux-serial-port-reading-can-i-change-size-of-input-buffer](https://www.researchgate.net/deref/https%3A%2F%2Fstackoverflow.com%2Fquestions%2F10815811%2Flinux-serial-port-reading-can-i-change-size-of-input-buffer)
