### PR TITLE
Added get_recording_state 

### DIFF
--- a/src/embodyserial/helpers.py
+++ b/src/embodyserial/helpers.py
@@ -100,6 +100,13 @@ class EmbodySendHelper:
         )
         return response_attribute.value
 
+    def get_recording_state(self) -> bool:
+        """Name of attribute makes no sence but is correct..."""
+        response_attribute = self.__do_send_get_attribute_request(
+            attributes.MeasurementDeactivatedAttribute.attribute_id
+        )
+        return response_attribute.value
+
     def get_files(self) -> list[tuple[str, int]]:
         """Get a list of tuples with file name and file size."""
         response = self.__sender.send(msg=codec.ListFiles(), timeout=120)


### PR DESCRIPTION
Added get_recording_state helper function for accessing the current recording state. Great for checking if the file has been closed and recording has been stopped, not having to rely on reports and will allow tests to check on a time-basis to confirm DUT has not stopped early etc.