### PR TITLE
Maintenance release 1.0.39: toolchain alignment, lint/type sharpening, drop Python 3.11

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.12"] # 3.13 is disabled until numpy is updated to 2.1+
+        python-version: ["3.12", "3.13"]
       fail-fast: false
     defaults:
       run:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.5
+    rev: v0.15.15
     hooks:
       # Run the linter (replaces flake8).
       - id: ruff

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
 
 ## Requirements
 
-- Python 3.11 or newer
+- Python 3.12 or newer
 - Access to private Aidee Health repositories on Github
 
 ## Installation

--- a/examples/file_download_example.py
+++ b/examples/file_download_example.py
@@ -10,21 +10,24 @@ from embodyserial.embodyserial import EmbodySerial
 from embodyserial.helpers import EmbodySendHelper
 
 
+logger = logging.getLogger(__name__)
+
+
 if __name__ == "__main__":
     logging.basicConfig(level=logging.INFO, format="%(asctime)s:%(levelname)s:%(message)s")
-    logging.info("Starting reporting example")
+    logger.info("Starting reporting example")
 
-    logging.info("Setting up communicator")
+    logger.info("Setting up communicator")
     # Connect to first available device
     embody_serial = EmbodySerial()
     send_helper = EmbodySendHelper(sender=embody_serial)
     files = send_helper.get_files()
     if len(files) > 0:
         for name, size in files:
-            logging.info(f"Downloading {name} ({round(size / 1024)}KB)")
+            logger.info("Downloading %s (%sKB)", name, round(size / 1024))
             file_name = embody_serial.download_file(file_name=name, size=size)
-            logging.info(f"Downloaded {file_name} ({round(size / 1024)}KB)")
+            logger.info("Downloaded %s (%sKB)", file_name, round(size / 1024))
     else:
-        logging.info("No files found on device")
+        logger.info("No files found on device")
 
     embody_serial.shutdown()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,7 +86,7 @@ invalid-return-type = "error"
 missing-argument = "error"
 too-many-positional-arguments = "error"
 unknown-argument = "error"
-non-subscriptable = "error"
+not-subscriptable = "error"
 not-iterable = "error"
 
 # Exception handling (Tier 1)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "Communicate with the embody device over a serial port"
 authors = [{name = "Aidee Health AS", email = "hello@aidee.io"}]
 license = "MIT"
 readme = "README.md"
-requires-python = ">=3.11,<4.0"
+requires-python = ">=3.12,<4.0"
 classifiers = [
     "Development Status :: 5 - Production/Stable",
 ]
@@ -19,8 +19,8 @@ dependencies= [
 dev = [
     "pytest>=7.2.0",
     "Pygments>=2.10.0",
-    "ruff>=0.11.5",
-    "ty>=0.0.2",
+    "ruff>=0.15.0",
+    "ty>=0.0.42",
     "pre-commit>=2.16.0",
     "pre-commit-hooks>=4.1.0",
 ]
@@ -54,25 +54,8 @@ markers = [
     "error_handling: Tests focused on exception handling and validation",
 ]
 
-[tool.coverage.paths]
-source = ["src", "*/site-packages"]
-tests = ["tests", "*/tests"]
-
-[tool.coverage.run]
-branch = true
-source = ["embodyserial", "tests"]
-
-[tool.coverage.report]
-show_missing = true
-fail_under = 2
-
-[tool.isort]
-profile = "black"
-force_single_line = true
-lines_after_imports = 2
-
 [tool.ty.environment]
-python-version = "3.11"  # Matches project requires-python
+python-version = "3.12"  # Matches project requires-python
 
 [tool.ty.rules]
 # Core type safety rules
@@ -118,10 +101,10 @@ ambiguous-protocol-member = "warn"
 
 [tool.ty.terminal]
 output-format = "full"             # Provides detailed error messages with full context
-error-on-warning = false           # Don't fail on warnings initially
+error-on-warning = true            # Treat warning-level rules as failures (config is clean)
 
 [tool.ruff]
-target-version = "py311"
+target-version = "py312"
 line-length = 120
 
 [tool.ruff.lint]
@@ -139,6 +122,11 @@ select = [
     "RUF",  # Ruff-specific rules
     "PTH",  # use pathlib
     "PL",   # Pylint
+    "SIM",  # flake8-simplify
+    "PT",   # flake8-pytest-style
+    "RET",  # flake8-return
+    "G",    # flake8-logging-format
+    "LOG",  # flake8-logging
 ]
 ignore = [
     "E203",   # Whitespace before ':'
@@ -153,12 +141,15 @@ ignore = [
     "B905",   # zip() without an explicit strict= parameter
     "PLR2004", # Magic value used in comparison
     "PLR0913", # Too many arguments
-    "I001",   # isort: skip
     "PTH123", # pathlib: skip
     "RUF012", # mutable-class-default
     "PLR0912", # Too many branches
     "PLR0915", # Too many statements
 ]
+
+[tool.ruff.lint.isort]
+force-single-line = true
+lines-after-imports = 2
 
 [tool.ruff.lint.pydocstyle]
 convention = "google"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "embody-serial"
-version = "1.0.38"
+version = "1.0.39"
 description = "Communicate with the embody device over a serial port"
 authors = [{name = "Aidee Health AS", email = "hello@aidee.io"}]
 license = "MIT"

--- a/src/embodyserial/__init__.py
+++ b/src/embodyserial/__init__.py
@@ -3,6 +3,7 @@
 import importlib.metadata
 import logging
 
+
 # Configure NullHandler by default to prevent unwanted logging output
 _library_logger = logging.getLogger("embodyserial")
 if not _library_logger.handlers:

--- a/src/embodyserial/cli.py
+++ b/src/embodyserial/cli.py
@@ -17,6 +17,7 @@ from embodyserial.helpers import EmbodySendHelper
 from embodyserial.listeners import FileDownloadListener
 from embodyserial.logging import configure_library_logging
 
+
 logger = logging.getLogger(__name__)
 
 
@@ -244,7 +245,7 @@ def __do_download_file(
 
         def on_file_download_failed(self, original_file_name: str, error: Exception) -> None:
             """Process file download failure."""
-            logger.error(f"Download failed for {original_file_name}: {error}")
+            logger.error("Download failed for %s: %s", original_file_name, error)
 
     listener = _DownloadListener()
     if retries == 0:

--- a/src/embodyserial/embodyserial.py
+++ b/src/embodyserial/embodyserial.py
@@ -415,8 +415,9 @@ class _ReaderThread(threading.Thread):
         if not self.alive:
             return
         self.alive = False
-        if hasattr(self.__serial, "cancel_read") and self.__serial.is_open:
-            self.__serial.cancel_read()  # ty: ignore[call-non-callable]
+        cancel_read = getattr(self.__serial, "cancel_read", None)
+        if callable(cancel_read) and self.__serial.is_open:
+            cancel_read()
         self.__message_listener_executor.shutdown(wait=True, cancel_futures=False)
         self.__response_message_listener_executor.shutdown(wait=True, cancel_futures=False)
         self.__file_download_listener_executor.shutdown(wait=True, cancel_futures=False)

--- a/src/embodyserial/embodyserial.py
+++ b/src/embodyserial/embodyserial.py
@@ -411,7 +411,7 @@ class _ReaderThread(threading.Thread):
         self.alive = False
         if hasattr(self.__serial, "cancel_read"):
             if self.__serial.is_open:
-                self.__serial.cancel_read()  # type: ignore[misc]
+                self.__serial.cancel_read()  # ty: ignore[call-non-callable]
         self.__message_listener_executor.shutdown(wait=True, cancel_futures=False)
         self.__response_message_listener_executor.shutdown(wait=True, cancel_futures=False)
         self.__file_download_listener_executor.shutdown(wait=True, cancel_futures=False)

--- a/src/embodyserial/embodyserial.py
+++ b/src/embodyserial/embodyserial.py
@@ -5,6 +5,7 @@ and subscribing for incoming messages from the device.
 """
 
 import concurrent.futures
+import contextlib
 import logging
 import os
 import re
@@ -15,12 +16,12 @@ import threading
 import time
 from abc import ABC
 from abc import abstractmethod
+from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor
 from concurrent.futures import TimeoutError
 from dataclasses import dataclass
 from operator import attrgetter
 from typing import Any
-from collections.abc import Callable
 from typing import TypeVar
 
 import serial
@@ -36,6 +37,7 @@ from embodyserial.listeners import ConnectionListener
 from embodyserial.listeners import FileDownloadListener
 from embodyserial.listeners import MessageListener
 from embodyserial.listeners import ResponseMessageListener
+
 
 logger = logging.getLogger(__name__)
 
@@ -78,10 +80,10 @@ class EmbodySerial(ConnectionListener, EmbodySender):
     ) -> None:
         if serial_port:
             self.__port = serial_port
-            logger.info(f"Using serial port {self.__port}")
+            logger.info("Using serial port %s", self.__port)
         elif not serial_instance:
             self.__port = EmbodySerial.find_first_serial_port()
-            logger.info(f"Using serial port {self.__port}")
+            logger.info("Using serial port %s", self.__port)
         self.__shutdown_lock = threading.Lock()
         if serial_instance:
             self.__serial = serial_instance
@@ -92,7 +94,7 @@ class EmbodySerial(ConnectionListener, EmbodySender):
                 if set_buffer_size:
                     buffer_set = set_buffer_size(rx_size=WINDOWS_RX_BUFFER, tx_size=WINDOWS_TX_BUFFER)
                     if buffer_set and buffer_set is not True:
-                        logger.warning(f"Failed to set buffer size for windows: {buffer_set}")
+                        logger.warning("Failed to set buffer size for windows: %s", buffer_set)
         self.__connected = True
         self.__sender = _MessageSender(self.__serial)
         self.__reader = _ReaderThread(serial_instance=self.__serial)
@@ -128,21 +130,21 @@ class EmbodySerial(ConnectionListener, EmbodySender):
                     try:
                         reset_input()
                     except (OSError, SerialException) as e:
-                        logger.debug(f"Failed to reset input buffer: {e}")
+                        logger.debug("Failed to reset input buffer: %s", e)
                 reset_output = getattr(self.__serial, "reset_output_buffer", None)
                 if reset_output:
                     try:
                         reset_output()
                     except (OSError, SerialException) as e:
-                        logger.debug(f"Failed to reset output buffer: {e}")
+                        logger.debug("Failed to reset output buffer: %s", e)
                 try:
                     self.__serial.close()
                 except (OSError, SerialException) as e:
-                    logger.warning(f"Failed to close port: {e}")
+                    logger.warning("Failed to close port: %s", e)
 
     def on_connected(self, connected: bool) -> None:
         """Implement connection listener interface and handle disconnect events"""
-        logger.debug(f"Connection event: {connected}")
+        logger.debug("Connection event: %s", connected)
         if not connected:
             self.shutdown()
 
@@ -187,13 +189,13 @@ class EmbodySerial(ConnectionListener, EmbodySender):
             try:
                 stored_file = self.download_file(file_name, file_size, listener, timeout, delay)
                 if stored_file:
-                    logger.info(f"File {file_name} downloaded to: {stored_file}")
+                    logger.info("File %s downloaded to: %s", file_name, stored_file)
                     return stored_file
-                logger.warning(f"Download failed for {file_name} (attempt: {retry})")
+                logger.warning("Download failed for %s (attempt: %s)", file_name, retry)
                 time.sleep(timeout_seconds_per_retry)
                 continue
             except (embodyexceptions.TimeoutError, embodyexceptions.CrcError, SerialException) as e:
-                logger.warning(f"Download failed for {file_name} (attempt: {retry}): {e}")
+                logger.warning("Download failed for %s (attempt: %s): %s", file_name, retry, e)
                 time.sleep(timeout_seconds_per_retry)
                 continue
         return None
@@ -231,30 +233,28 @@ class EmbodySerial(ConnectionListener, EmbodySender):
     @staticmethod
     def __port_is_alive(port: Any) -> bool:
         """Check if port has an active embody device."""
-        logger.debug(f"Checking candidate port: {port}")
+        logger.debug("Checking candidate port: %s", port)
         ser = None
         try:
             ser = serial.Serial(port=port.device, baudrate=BAUD_RATE, timeout=1)
             in_waiting = ser.in_waiting
             if in_waiting and in_waiting > 0:
-                logger.debug(f"Flushing input buffer ({in_waiting} bytes)")
+                logger.debug("Flushing input buffer (%s bytes)", in_waiting)
                 ser.read(in_waiting)
             ser.reset_input_buffer()
             ser.reset_output_buffer()
             ser.write(codec.Heartbeat().encode())
             expected_response = codec.HeartbeatResponse().encode()
             response = ser.read(len(expected_response))
-            logger.debug(f"Response: {response.hex()} (expected: {expected_response.hex()})")
+            logger.debug("Response: %s (expected: %s)", response.hex(), expected_response.hex())
             return response == expected_response
         except (SerialException, OSError) as e:
-            logger.debug(f"Exception raised for port check: {e}")
+            logger.debug("Exception raised for port check: %s", e)
             return False
         finally:
             if ser and ser.is_open:
-                try:
+                with contextlib.suppress(OSError, SerialException):
                     ser.close()
-                except (OSError, SerialException):
-                    pass
 
 
 class _MessageSender(ResponseMessageListener):
@@ -283,7 +283,7 @@ class _MessageSender(ResponseMessageListener):
 
         Sets the local response message and notifies the waiting sender thread
         """
-        logger.debug(f"Response message received: {msg}")
+        logger.debug("Response message received: %s", msg)
         self.__current_response_message = msg
         self.__response_event.set()
 
@@ -296,7 +296,8 @@ class _MessageSender(ResponseMessageListener):
             return future.result(timeout + 1 if timeout else 1)
         except TimeoutError:
             logger.warning(
-                f"No response received for message within timeout: {msg}",
+                "No response received for message within timeout: %s",
+                msg,
                 exc_info=False,
             )
             return None
@@ -310,16 +311,19 @@ class _MessageSender(ResponseMessageListener):
         with self._send_lock:
             if not self.__serial.is_open:
                 return None
-            logger.debug(f"Sending message: {msg}, encoded: {msg.encode().hex()}")
+            logger.debug("Sending message: %s, encoded: %s", msg, msg.encode().hex())
             try:
                 self.__response_event.clear()
                 self.__serial.write(msg.encode())
             except serial.SerialException as e:
-                logger.warning(f"Error sending message: {e!s}", exc_info=False)
+                logger.warning("Error sending message: %s", e, exc_info=False)
                 return None
-            if wait_for_response_secs and wait_for_response_secs > 0:
-                if self.__response_event.wait(wait_for_response_secs):
-                    return self.__current_response_message
+            if (
+                wait_for_response_secs
+                and wait_for_response_secs > 0
+                and self.__response_event.wait(wait_for_response_secs)
+            ):
+                return self.__current_response_message
             return None
 
 
@@ -387,7 +391,7 @@ class _ReaderThread(threading.Thread):
         self.__file_mode = True
         try:
             uart = codec.GetFileUart(types.File(original_file_name))
-            logger.debug(f"Sending message: {uart}, encoded: {uart.encode().hex()}")
+            logger.debug("Sending message: %s, encoded: %s", uart, uart.encode().hex())
             self.__serial.write(uart.encode())
             if not self.__file_event.wait(timeout):
                 raise embodyexceptions.MissingResponseError("No file received within timeout")
@@ -409,9 +413,8 @@ class _ReaderThread(threading.Thread):
         if not self.alive:
             return
         self.alive = False
-        if hasattr(self.__serial, "cancel_read"):
-            if self.__serial.is_open:
-                self.__serial.cancel_read()  # ty: ignore[call-non-callable]
+        if hasattr(self.__serial, "cancel_read") and self.__serial.is_open:
+            self.__serial.cancel_read()  # ty: ignore[call-non-callable]
         self.__message_listener_executor.shutdown(wait=True, cancel_futures=False)
         self.__response_message_listener_executor.shutdown(wait=True, cancel_futures=False)
         self.__file_download_listener_executor.shutdown(wait=True, cancel_futures=False)
@@ -432,19 +435,19 @@ class _ReaderThread(threading.Thread):
                 raw_header = b""
             except serial.SerialException as ser:
                 # probably some I/O problem such as disconnected USB serial adapters -> exit
-                logger.info(f"Serial port is closed (SerialException) {ser!s}")
+                logger.info("Serial port is closed (SerialException) %s", ser)
                 break
             except TypeError:
                 # read returned empty buffer
                 break
             except OSError as ose:
-                logger.info(f"OS Error reading from socket (OSError): {ose!s}")
+                logger.info("OS Error reading from socket (OSError): %s", ose)
                 break
             except ValueError as ve:
-                logger.info(f"ValueError reading from socket (Probably disconnected): {ve!s}")
+                logger.info("ValueError reading from socket (Probably disconnected): %s", ve)
                 break
             except Exception as e:
-                logger.info(f"Unexpected exception reading from socket: {e!s} - disconnecting")
+                logger.info("Unexpected exception reading from socket: %s - disconnecting", e)
                 break
         self.alive = False
         self.__file_event.set()
@@ -463,7 +466,7 @@ class _ReaderThread(threading.Thread):
             raise embodyexceptions.CrcError("Missing/too short crc")
 
         self.__async_notify_file_download_in_progress(f, f.file_size, 100, kbps)
-        logger.debug(f"Read {round(f.file_size / 1024, 2)}KB in {elapsed} secs - {kbps}KB/s")
+        logger.debug("Read %sKB in %s secs - %sKB/s", round(f.file_size / 1024, 2), elapsed, kbps)
 
         (crc_received,) = struct.unpack(">H", raw_crc_received)
         calculated_crc = crc.crc16(data=file_data)
@@ -472,12 +475,13 @@ class _ReaderThread(threading.Thread):
                 raise embodyexceptions.CrcError(
                     f"Invalid crc - calculated {hex(calculated_crc)}, but received {hex(crc_received)}"
                 )
-            logger.warning(f"IGNORING invalid crc - calculated {hex(calculated_crc)}, but received {hex(crc_received)}")
+            logger.warning(
+                "IGNORING invalid crc - calculated %s, but received %s", hex(calculated_crc), hex(crc_received)
+            )
 
-        tmp = tempfile.NamedTemporaryFile(delete=False)
-        tmp.write(file_data)
-        tmp.flush()
-        tmp.close()
+        with tempfile.NamedTemporaryFile(delete=False) as tmp:
+            tmp.write(file_data)
+            tmp.flush()
         f.file_name = tmp.name
         self.__async_notify_file_download_completed(f, kbps)
 
@@ -593,9 +597,9 @@ class _ReaderThread(threading.Thread):
 
     def __read_protocol_message(self, raw_header: bytes) -> None:
         """Read next message from input."""
-        logger.debug(f"RECEIVE: Received header {raw_header.hex()}")
+        logger.debug("RECEIVE: Received header %s", raw_header.hex())
         msg_type, length = struct.unpack(">BH", raw_header)
-        logger.debug(f"RECEIVE: Received msg type: {msg_type}, length: {length}")
+        logger.debug("RECEIVE: Received msg type: %s, length: %s", msg_type, length)
         if length > MAX_PROTOCOL_MESSAGE_LENGTH:
             raise ValueError(f"Message length too long: {length}")
         remaining_length = length - 3
@@ -606,7 +610,8 @@ class _ReaderThread(threading.Thread):
             time.sleep(0.001)
         if raw_message:
             logger.debug(
-                f"RECEIVE: Received raw msg: {raw_message.hex() if len(raw_message) <= 1024 else raw_message[0:1023].hex()}"
+                "RECEIVE: Received raw msg: %s",
+                raw_message.hex() if len(raw_message) <= 1024 else raw_message[0:1023].hex(),
             )
             try:
                 msg = codec.decode(raw_message)
@@ -614,7 +619,8 @@ class _ReaderThread(threading.Thread):
                     self.__handle_incoming_message(msg)
             except (struct.error, ValueError, TypeError) as e:
                 logger.warning(
-                    f"Error processing protocol message, error: {e!s}",
+                    "Error processing protocol message, error: %s",
+                    e,
                     exc_info=True,
                 )
 
@@ -625,7 +631,7 @@ class _ReaderThread(threading.Thread):
             self.__handle_response_message(msg)
 
     def __handle_message(self, msg: codec.Message) -> None:
-        logger.debug(f"Handling new message: {msg}")
+        logger.debug("Handling new message: %s", msg)
         if len(self.__message_listeners) == 0:
             return
         for listener in self.__message_listeners:
@@ -636,13 +642,13 @@ class _ReaderThread(threading.Thread):
         try:
             listener.message_received(msg)
         except Exception as e:
-            logger.warning(f"Error notifying listener: {e!s}", exc_info=True)
+            logger.warning("Error notifying listener: %s", e, exc_info=True)
 
     def add_message_listener(self, listener: MessageListener) -> None:
         self.__message_listeners.append(listener)
 
     def __handle_response_message(self, msg: codec.Message) -> None:
-        logger.debug(f"Handling new response message: {msg}")
+        logger.debug("Handling new response message: %s", msg)
         if len(self.__response_message_listeners) == 0:
             return
         for listener in self.__response_message_listeners:
@@ -653,7 +659,7 @@ class _ReaderThread(threading.Thread):
         try:
             listener.response_message_received(msg)
         except Exception as e:
-            logger.warning(f"Error notifying listener: {e!s}", exc_info=True)
+            logger.warning("Error notifying listener: %s", e, exc_info=True)
 
     def add_response_message_listener(self, listener: ResponseMessageListener) -> None:
         self.__response_message_listeners.append(listener)
@@ -672,7 +678,7 @@ class _ReaderThread(threading.Thread):
         try:
             listener.on_connected(connected)
         except Exception as e:
-            logger.warning(f"Error notifying connection listener: {e!s}", exc_info=True)
+            logger.warning("Error notifying connection listener: %s", e, exc_info=True)
 
     @staticmethod
     def __notify_file_download_progress(
@@ -685,7 +691,7 @@ class _ReaderThread(threading.Thread):
         try:
             listener.on_file_download_progress(original_file_name, size, progress, kbps)
         except Exception as e:
-            logger.warning(f"Error notifying file download listener: {e!s}", exc_info=True)
+            logger.warning("Error notifying file download listener: %s", e, exc_info=True)
 
     @staticmethod
     def __notify_file_download_complete(
@@ -694,7 +700,7 @@ class _ReaderThread(threading.Thread):
         try:
             listener.on_file_download_complete(original_file_name, path, kbps)
         except Exception as e:
-            logger.warning(f"Error notifying file download listener: {e!s}", exc_info=True)
+            logger.warning("Error notifying file download listener: %s", e, exc_info=True)
 
     @staticmethod
     def __notify_file_download_failed(
@@ -703,4 +709,4 @@ class _ReaderThread(threading.Thread):
         try:
             listener.on_file_download_failed(original_file_name, error)
         except Exception as e:
-            logger.warning(f"Error notifying file download listener: {e!s}", exc_info=True)
+            logger.warning("Error notifying file download listener: %s", e, exc_info=True)

--- a/src/embodyserial/embodyserial.py
+++ b/src/embodyserial/embodyserial.py
@@ -164,7 +164,9 @@ class EmbodySerial(ConnectionListener, EmbodySender):
           CrcError if invalid crc.
         """
         if size == 0:
-            return tempfile.NamedTemporaryFile(delete=False).name
+            fd, path = tempfile.mkstemp()
+            os.close(fd)
+            return path
 
         # lock send to prevent sending other messages while downloading
         return self.__sender.execute_with_send_lock(

--- a/src/embodyserial/helpers.py
+++ b/src/embodyserial/helpers.py
@@ -3,8 +3,8 @@
 import logging
 import struct
 import time
-from datetime import datetime
 from datetime import UTC
+from datetime import datetime
 from typing import TypeVar
 
 from embodycodec import attributes
@@ -15,6 +15,7 @@ from serial.serialutil import SerialException
 from embodyserial.embodyserial import EmbodySender
 from embodyserial.exceptions import MissingResponseError
 from embodyserial.exceptions import NackError
+
 
 logger = logging.getLogger(__name__)
 
@@ -125,13 +126,13 @@ class EmbodySendHelper:
         for retry in range(1, retries + 1):
             try:
                 if self.delete_file(file_name):
-                    logger.info(f"Deleted file on device: {file_name}")
+                    logger.info("Deleted file on device: %s", file_name)
                     return True
-                logger.warning(f"Delete failed for {file_name} (attempt: {retry})")
+                logger.warning("Delete failed for %s (attempt: %s)", file_name, retry)
                 time.sleep(timeout_seconds_per_retry)
                 continue
             except (MissingResponseError, NackError, SerialException) as e:
-                logger.warning(f"Delete failed for {file_name} (attempt: {retry}): {e}")
+                logger.warning("Delete failed for %s (attempt: %s): %s", file_name, retry, e)
                 time.sleep(timeout_seconds_per_retry)
                 continue
         return False

--- a/src/embodyserial/logging.py
+++ b/src/embodyserial/logging.py
@@ -2,6 +2,7 @@
 
 import logging
 
+
 # Library root logger name
 LIBRARY_LOGGER_NAME = "embodyserial"
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,9 +29,7 @@ class DummySerial(SerialBase):
         if not self.__response_data or self.__response_data_pos + size > len(self.__response_data):
             self.__response_data_available.clear()
             self.__response_data_available.wait()
-        part = self.__response_data[
-            self.__response_data_pos : self.__response_data_pos + size
-        ]  # ty: ignore[not-subscriptable]
+        part = self.__response_data[self.__response_data_pos : self.__response_data_pos + size]  # ty: ignore[not-subscriptable]
         self.__response_data_pos += size
         return part
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,7 +29,9 @@ class DummySerial(SerialBase):
         if not self.__response_data or self.__response_data_pos + size > len(self.__response_data):
             self.__response_data_available.clear()
             self.__response_data_available.wait()
-        part = self.__response_data[self.__response_data_pos : self.__response_data_pos + size]  # type: ignore[index]
+        part = self.__response_data[
+            self.__response_data_pos : self.__response_data_pos + size
+        ]  # ty: ignore[not-subscriptable]
         self.__response_data_pos += size
         return part
 

--- a/tests/test_concurrent_callbacks.py
+++ b/tests/test_concurrent_callbacks.py
@@ -43,7 +43,7 @@ class TestConcurrentCallbacks:
             communicator.add_message_listener(listener)
 
         # Send one message - all three listeners will be called
-        reader = communicator._EmbodySerial__reader  # type: ignore[attr-defined]
+        reader = communicator._EmbodySerial__reader  # ty: ignore[unresolved-attribute]
         reader._ReaderThread__handle_message(codec.Heartbeat())
 
         # Wait for all callbacks to complete
@@ -85,7 +85,7 @@ class TestConcurrentCallbacks:
         communicator.add_message_listener(SendingListener())
 
         # Trigger callback that will attempt to send
-        reader = communicator._EmbodySerial__reader  # type: ignore[attr-defined]
+        reader = communicator._EmbodySerial__reader  # ty: ignore[unresolved-attribute]
         reader._ReaderThread__handle_message(codec.Heartbeat())
 
         # Should complete without deadlock
@@ -112,7 +112,7 @@ class TestConcurrentCallbacks:
                 response_received.set()
 
         communicator.add_message_listener(TestMessageListener())
-        reader = communicator._EmbodySerial__reader  # type: ignore[attr-defined]
+        reader = communicator._EmbodySerial__reader  # ty: ignore[unresolved-attribute]
         reader.add_response_message_listener(TestResponseListener())
 
         # Send both types of messages
@@ -140,7 +140,10 @@ class TestConcurrentCallbacks:
 
         # Start a file download in background
         def download_file():
-            with patch.object(communicator._EmbodySerial__reader, "download_file") as mock_download:  # type: ignore[attr-defined]
+            with patch.object(
+                communicator._EmbodySerial__reader,  # ty: ignore[unresolved-attribute]
+                "download_file",
+            ) as mock_download:
                 import tempfile
 
                 with tempfile.NamedTemporaryFile(suffix=".bin", delete=False) as tmp:
@@ -155,7 +158,7 @@ class TestConcurrentCallbacks:
         time.sleep(0.05)
 
         # Trigger callback - should still execute despite download
-        reader = communicator._EmbodySerial__reader  # type: ignore[attr-defined]
+        reader = communicator._EmbodySerial__reader  # ty: ignore[unresolved-attribute]
         reader._ReaderThread__handle_message(codec.Heartbeat())
 
         # Callback should complete
@@ -189,7 +192,7 @@ class TestConcurrentCallbacks:
         communicator.add_message_listener(BlockingMessageListener())
 
         # Add response listener
-        reader = communicator._EmbodySerial__reader  # type: ignore[attr-defined]
+        reader = communicator._EmbodySerial__reader  # ty: ignore[unresolved-attribute]
         reader.add_response_message_listener(FastResponseListener())
 
         # Trigger blocking message callback

--- a/tests/test_concurrent_callbacks.py
+++ b/tests/test_concurrent_callbacks.py
@@ -1,5 +1,6 @@
 """Test concurrent callback processing with max_workers=3."""
 
+import tempfile
 import threading
 import time
 from unittest.mock import patch
@@ -8,7 +9,8 @@ import pytest
 from embodycodec import codec
 
 from embodyserial import embodyserial as serialcomm
-from embodyserial.listeners import MessageListener, ResponseMessageListener
+from embodyserial.listeners import MessageListener
+from embodyserial.listeners import ResponseMessageListener
 from tests.conftest import DummySerial
 
 
@@ -144,8 +146,6 @@ class TestConcurrentCallbacks:
                 communicator._EmbodySerial__reader,  # ty: ignore[unresolved-attribute]
                 "download_file",
             ) as mock_download:
-                import tempfile
-
                 with tempfile.NamedTemporaryFile(suffix=".bin", delete=False) as tmp:
                     mock_download.return_value = tmp.name
                 time.sleep(0.1)  # Simulate download time

--- a/tests/test_connection_handling.py
+++ b/tests/test_connection_handling.py
@@ -16,8 +16,8 @@ class TestConnectionHandling:
         communicator = serialcomm.EmbodySerial(serial_port="Dummy", serial_instance=serial)
 
         # Simulate immediate disconnection
-        with communicator._EmbodySerial__shutdown_lock:  # type: ignore[attr-defined]
-            communicator._EmbodySerial__connected = False  # type: ignore[attr-defined]
+        with communicator._EmbodySerial__shutdown_lock:  # ty: ignore[unresolved-attribute]
+            communicator._EmbodySerial__connected = False  # ty: ignore[unresolved-attribute]
 
         result = communicator.download_file_with_retries(file_name="test.bin", file_size=1024, retries=3)
 

--- a/tests/test_error_validation.py
+++ b/tests/test_error_validation.py
@@ -1,15 +1,17 @@
 """Test error handling and validation improvements."""
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
+from unittest.mock import patch
 
 import pytest
 from embodycodec import codec
 from serial.serialutil import SerialException
 
-from embodyserial.exceptions import MissingResponseError, NackError
+from embodyserial import embodyserial as serialcomm
+from embodyserial.exceptions import MissingResponseError
+from embodyserial.exceptions import NackError
 from embodyserial.helpers import EmbodySendHelper
 from tests.conftest import DummySerial
-from embodyserial import embodyserial as serialcomm
 
 
 @pytest.mark.error_handling
@@ -153,8 +155,10 @@ class TestExceptionSpecificity:
         mock_response = MagicMock(spec=codec.GetAttributeResponse)
         mock_response.value = wrong_attribute
 
-        with patch.object(communicator, "send", return_value=mock_response):
-            with pytest.raises(TypeError, match="Expected TemperatureAttribute, got WrongAttribute"):
-                helper.get_temperature()
+        with (
+            patch.object(communicator, "send", return_value=mock_response),
+            pytest.raises(TypeError, match="Expected TemperatureAttribute, got WrongAttribute"),
+        ):
+            helper.get_temperature()
 
         communicator.shutdown()

--- a/tests/test_file_download.py
+++ b/tests/test_file_download.py
@@ -8,6 +8,7 @@ import pytest
 from embodycodec import crc
 
 from embodyserial import embodyserial as serialcomm
+from embodyserial.exceptions import CrcError
 from tests.conftest import DummySerial
 
 
@@ -150,8 +151,6 @@ class TestSmallFileDownload:
             serial.set_read_data(full_data)
 
         threading.Thread(target=set_data_after_delay, daemon=True).start()
-
-        from embodyserial.exceptions import CrcError
 
         with pytest.raises(CrcError):
             communicator.download_file(file_name="bad_crc.bin", size=1, timeout=5)

--- a/tests/test_file_download.py
+++ b/tests/test_file_download.py
@@ -22,6 +22,18 @@ def _create_file_data_with_crc(file_content: bytes) -> bytes:
 class TestSmallFileDownload:
     """Test small file download edge cases."""
 
+    def test_0_byte_file_download(self):
+        """Verify 0-byte file returns a path to a valid empty file."""
+        serial = DummySerial()
+        communicator = serialcomm.EmbodySerial(serial_port="Dummy", serial_instance=serial)
+
+        result = communicator.download_file(file_name="empty.bin", size=0, timeout=5)
+
+        assert result is not None
+        with open(result, "rb") as f:
+            assert f.read() == b""
+        communicator.shutdown()
+
     def test_1_byte_file_download(self):
         """Verify 1-byte file downloads correctly (Bug #2 fix)."""
         # For 1-byte file: first_bytes will contain [file_byte, crc_byte_1, crc_byte_2]

--- a/tests/test_resource_management.py
+++ b/tests/test_resource_management.py
@@ -1,6 +1,7 @@
 """Test resource management and cleanup."""
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
+from unittest.mock import patch
 
 import pytest
 from serial.serialutil import SerialException
@@ -58,11 +59,13 @@ class TestShutdownResilience:
         communicator = serialcomm.EmbodySerial(serial_port="Dummy", serial_instance=serial)
 
         # Mock serial to raise on buffer operations
-        with patch.object(serial, "reset_input_buffer", side_effect=OSError("Error")):
-            with patch.object(serial, "reset_output_buffer", side_effect=OSError("Error")):
-                with patch.object(serial, "close", side_effect=SerialException("Error")):
-                    # Should not raise
-                    communicator.shutdown()
+        with (
+            patch.object(serial, "reset_input_buffer", side_effect=OSError("Error")),
+            patch.object(serial, "reset_output_buffer", side_effect=OSError("Error")),
+            patch.object(serial, "close", side_effect=SerialException("Error")),
+        ):
+            # Should not raise
+            communicator.shutdown()
 
     def test_double_shutdown_is_safe(self):
         """Verify calling shutdown twice doesn't cause issues."""

--- a/tests/test_resource_management.py
+++ b/tests/test_resource_management.py
@@ -25,7 +25,7 @@ class TestPortManagement:
             mock_port = MagicMock()
             mock_port.device = "/dev/ttyUSB0"
 
-            result = serialcomm.EmbodySerial._EmbodySerial__port_is_alive(mock_port)  # type: ignore[attr-defined]
+            result = serialcomm.EmbodySerial._EmbodySerial__port_is_alive(mock_port)  # ty: ignore[unresolved-attribute]
 
             assert result is False
             mock_instance.close.assert_called_once()
@@ -42,7 +42,7 @@ class TestPortManagement:
             mock_port = MagicMock()
             mock_port.device = "/dev/ttyUSB0"
 
-            result = serialcomm.EmbodySerial._EmbodySerial__port_is_alive(mock_port)  # type: ignore[attr-defined]
+            result = serialcomm.EmbodySerial._EmbodySerial__port_is_alive(mock_port)  # ty: ignore[unresolved-attribute]
 
             assert result is True
             mock_instance.close.assert_called_once()
@@ -94,7 +94,7 @@ class TestThreadExecutorManagement:
         serial = DummySerial()
         communicator = serialcomm.EmbodySerial(serial_port="Dummy", serial_instance=serial)
 
-        reader = communicator._EmbodySerial__reader  # type: ignore[attr-defined]
+        reader = communicator._EmbodySerial__reader  # ty: ignore[unresolved-attribute]
 
         # Should have three separate executors
         assert hasattr(reader, "_ReaderThread__message_listener_executor")
@@ -118,7 +118,7 @@ class TestThreadExecutorManagement:
         serial = DummySerial()
         communicator = serialcomm.EmbodySerial(serial_port="Dummy", serial_instance=serial)
 
-        reader = communicator._EmbodySerial__reader  # type: ignore[attr-defined]
+        reader = communicator._EmbodySerial__reader  # ty: ignore[unresolved-attribute]
         msg_executor = reader._ReaderThread__message_listener_executor
         rsp_executor = reader._ReaderThread__response_message_listener_executor
         file_executor = reader._ReaderThread__file_download_listener_executor

--- a/uv.lock
+++ b/uv.lock
@@ -40,7 +40,7 @@ wheels = [
 
 [[package]]
 name = "embody-serial"
-version = "1.0.38"
+version = "1.0.39"
 source = { editable = "." }
 dependencies = [
     { name = "embody-codec" },

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,6 @@
 version = 1
 revision = 3
-requires-python = ">=3.11, <4.0"
+requires-python = ">=3.12, <4.0"
 
 [[package]]
 name = "cfgv"
@@ -31,11 +31,11 @@ wheels = [
 
 [[package]]
 name = "embody-codec"
-version = "1.0.39"
+version = "1.0.40"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/33/a9/ba7ed6811628bd423e8341d1d52470badb41596184df18f72d1f5c5e619c/embody_codec-1.0.39.tar.gz", hash = "sha256:c9990f7c84b44adc35fde549ad49e0c0069d10eb6cec682db3ad5d4752a4a557", size = 18503, upload-time = "2025-12-20T11:13:33.743Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/10/fe/15153d971bace3b64ee56bb93358b91e8ce618425e071de0de41082b22c6/embody_codec-1.0.40.tar.gz", hash = "sha256:30d0d4b05c3c2fd30b66421bb0a63f4464aef273893b7630eb0a90fa039f0986", size = 18535, upload-time = "2026-06-02T16:14:44.413Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ae/4f/aa70a5a1274a84a57d86edc04c4c213a1ca43f2d13a6fda832daec5dcec1/embody_codec-1.0.39-py3-none-any.whl", hash = "sha256:413d00e8a8aaf2636066259ac0debf45c04a54436d5f26bebbacf0f480411f28", size = 20266, upload-time = "2025-12-20T11:13:32.544Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/62/011a3c571e45810ee57c454009fa23b854424812e278d3631bbab429fab2/embody_codec-1.0.40-py3-none-any.whl", hash = "sha256:2ab265099172b7ef6e294c71ff0972e7c259dee49b97bdfe4e7bfcdee7c2d95a", size = 20336, upload-time = "2026-06-02T16:14:43.438Z" },
 ]
 
 [[package]]
@@ -69,8 +69,8 @@ dev = [
     { name = "pre-commit-hooks", specifier = ">=4.1.0" },
     { name = "pygments", specifier = ">=2.10.0" },
     { name = "pytest", specifier = ">=7.2.0" },
-    { name = "ruff", specifier = ">=0.11.5" },
-    { name = "ty", specifier = ">=0.0.2" },
+    { name = "ruff", specifier = ">=0.15.0" },
+    { name = "ty", specifier = ">=0.0.42" },
 ]
 
 [[package]]
@@ -217,15 +217,6 @@ version = "6.0.3"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6d/16/a95b6757765b7b031c9374925bb718d55e0a9ba8a1b6a12d25962ea44347/pyyaml-6.0.3-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:44edc647873928551a01e7a563d7452ccdebee747728c1080d881d68af7b997e", size = 185826, upload-time = "2025-09-25T21:31:58.655Z" },
-    { url = "https://files.pythonhosted.org/packages/16/19/13de8e4377ed53079ee996e1ab0a9c33ec2faf808a4647b7b4c0d46dd239/pyyaml-6.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:652cb6edd41e718550aad172851962662ff2681490a8a711af6a4d288dd96824", size = 175577, upload-time = "2025-09-25T21:32:00.088Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/62/d2eb46264d4b157dae1275b573017abec435397aa59cbcdab6fc978a8af4/pyyaml-6.0.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:10892704fc220243f5305762e276552a0395f7beb4dbf9b14ec8fd43b57f126c", size = 775556, upload-time = "2025-09-25T21:32:01.31Z" },
-    { url = "https://files.pythonhosted.org/packages/10/cb/16c3f2cf3266edd25aaa00d6c4350381c8b012ed6f5276675b9eba8d9ff4/pyyaml-6.0.3-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:850774a7879607d3a6f50d36d04f00ee69e7fc816450e5f7e58d7f17f1ae5c00", size = 882114, upload-time = "2025-09-25T21:32:03.376Z" },
-    { url = "https://files.pythonhosted.org/packages/71/60/917329f640924b18ff085ab889a11c763e0b573da888e8404ff486657602/pyyaml-6.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b8bb0864c5a28024fac8a632c443c87c5aa6f215c0b126c449ae1a150412f31d", size = 806638, upload-time = "2025-09-25T21:32:04.553Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/6f/529b0f316a9fd167281a6c3826b5583e6192dba792dd55e3203d3f8e655a/pyyaml-6.0.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1d37d57ad971609cf3c53ba6a7e365e40660e3be0e5175fa9f2365a379d6095a", size = 767463, upload-time = "2025-09-25T21:32:06.152Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/6a/b627b4e0c1dd03718543519ffb2f1deea4a1e6d42fbab8021936a4d22589/pyyaml-6.0.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:37503bfbfc9d2c40b344d06b2199cf0e96e97957ab1c1b546fd4f87e53e5d3e4", size = 794986, upload-time = "2025-09-25T21:32:07.367Z" },
-    { url = "https://files.pythonhosted.org/packages/45/91/47a6e1c42d9ee337c4839208f30d9f09caa9f720ec7582917b264defc875/pyyaml-6.0.3-cp311-cp311-win32.whl", hash = "sha256:8098f252adfa6c80ab48096053f512f2321f0b998f98150cea9bd23d83e1467b", size = 142543, upload-time = "2025-09-25T21:32:08.95Z" },
-    { url = "https://files.pythonhosted.org/packages/da/e3/ea007450a105ae919a72393cb06f122f288ef60bba2dc64b26e2646fa315/pyyaml-6.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:9f3bfb4965eb874431221a3ff3fdcddc7e74e3b07799e0e84ca4a0f867d449bf", size = 158763, upload-time = "2025-09-25T21:32:09.96Z" },
     { url = "https://files.pythonhosted.org/packages/d1/33/422b98d2195232ca1826284a76852ad5a86fe23e31b009c9886b2d0fb8b2/pyyaml-6.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7f047e29dcae44602496db43be01ad42fc6f1cc0d8cd6c83d342306c32270196", size = 182063, upload-time = "2025-09-25T21:32:11.445Z" },
     { url = "https://files.pythonhosted.org/packages/89/a0/6cf41a19a1f2f3feab0e9c0b74134aa2ce6849093d5517a0c550fe37a648/pyyaml-6.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fc09d0aa354569bc501d4e787133afc08552722d3ab34836a80547331bb5d4a0", size = 173973, upload-time = "2025-09-25T21:32:12.492Z" },
     { url = "https://files.pythonhosted.org/packages/ed/23/7a778b6bd0b9a8039df8b1b1d80e2e2ad78aa04171592c8a5c43a56a6af4/pyyaml-6.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9149cad251584d5fb4981be1ecde53a1ca46c891a79788c0df828d2f166bda28", size = 775116, upload-time = "2025-09-25T21:32:13.652Z" },

--- a/uv.lock
+++ b/uv.lock
@@ -22,11 +22,11 @@ wheels = [
 
 [[package]]
 name = "distlib"
-version = "0.4.0"
+version = "0.4.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/96/8e/709914eb2b5749865801041647dc7f4e6d00b549cfe88b65ca192995f07c/distlib-0.4.0.tar.gz", hash = "sha256:feec40075be03a04501a973d81f633735b4b69f98b05450592310c0f401a4e0d", size = 614605, upload-time = "2025-07-17T16:52:00.465Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/86/b2/d6fc3f2347f43dada79e5ff118493e8109c98400a0e29a1d5264a3aa479b/distlib-0.4.1.tar.gz", hash = "sha256:c3804d0d2d4b5fcd44036eb860cb6660485fcdf5c2aba53dc324d805837ea65b", size = 610526, upload-time = "2026-06-02T11:17:40.691Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/33/6b/e0547afaf41bf2c42e52430072fa5658766e3d65bd4b03a563d1b6336f57/distlib-0.4.0-py2.py3-none-any.whl", hash = "sha256:9659f7d87e46584a30b5780e43ac7a2143098441670ff0a49d5f9034c54a6c16", size = 469047, upload-time = "2025-07-17T16:51:58.613Z" },
+    { url = "https://files.pythonhosted.org/packages/25/18/3497c4fa83a76dcb154923fd2075522e8dd6995ecee4093c00ae18160046/distlib-0.4.1-py2.py3-none-any.whl", hash = "sha256:9c2c552c68cbadc619f2d0ed3a69e27c351a3f4c9baa9ffb7df9e9cdc3d19a97", size = 469216, upload-time = "2026-06-02T11:17:38.779Z" },
 ]
 
 [[package]]
@@ -75,20 +75,20 @@ dev = [
 
 [[package]]
 name = "filelock"
-version = "3.20.3"
+version = "3.29.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/1d/65/ce7f1b70157833bf3cb851b556a37d4547ceafc158aa9b34b36782f23696/filelock-3.20.3.tar.gz", hash = "sha256:18c57ee915c7ec61cff0ecf7f0f869936c7c30191bb0cf406f1341778d0834e1", size = 19485, upload-time = "2026-01-09T17:55:05.421Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b5/fe/997687a931ab51049acce6fa1f23e8f01216374ea81374ddee763c493db5/filelock-3.29.0.tar.gz", hash = "sha256:69974355e960702e789734cb4871f884ea6fe50bd8404051a3530bc07809cf90", size = 57571, upload-time = "2026-04-19T15:39:10.068Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b5/36/7fb70f04bf00bc646cd5bb45aa9eddb15e19437a28b8fb2b4a5249fac770/filelock-3.20.3-py3-none-any.whl", hash = "sha256:4b0dda527ee31078689fc205ec4f1c1bf7d56cf88b6dc9426c4f230e46c2dce1", size = 16701, upload-time = "2026-01-09T17:55:04.334Z" },
+    { url = "https://files.pythonhosted.org/packages/81/47/dd9a212ef6e343a6857485ffe25bba537304f1913bdbed446a23f7f592e1/filelock-3.29.0-py3-none-any.whl", hash = "sha256:96f5f6344709aa1572bbf631c640e4ebeeb519e08da902c39a001882f30ac258", size = 39812, upload-time = "2026-04-19T15:39:08.752Z" },
 ]
 
 [[package]]
 name = "identify"
-version = "2.6.15"
+version = "2.6.19"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ff/e7/685de97986c916a6d93b3876139e00eef26ad5bbbd61925d670ae8013449/identify-2.6.15.tar.gz", hash = "sha256:e4f4864b96c6557ef2a1e1c951771838f4edc9df3a72ec7118b338801b11c7bf", size = 99311, upload-time = "2025-10-02T17:43:40.631Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/52/63/51723b5f116cc04b061cb6f5a561790abf249d25931d515cd375e063e0f4/identify-2.6.19.tar.gz", hash = "sha256:6be5020c38fcb07da56c53733538a3081ea5aa70d36a156f83044bfbf9173842", size = 99567, upload-time = "2026-04-17T18:39:50.265Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0f/1c/e5fd8f973d4f375adb21565739498e2e9a1e54c858a97b9a8ccfdc81da9b/identify-2.6.15-py2.py3-none-any.whl", hash = "sha256:1181ef7608e00704db228516541eb83a88a9f94433a8c80bb9b5bd54b1d81757", size = 99183, upload-time = "2025-10-02T17:43:39.137Z" },
+    { url = "https://files.pythonhosted.org/packages/94/84/d9273cd09688070a6523c4aee4663a8538721b2b755c4962aafae0011e72/identify-2.6.19-py2.py3-none-any.whl", hash = "sha256:20e6a87f786f768c092a721ad107fc9df0eb89347be9396cadf3f4abbd1fb78a", size = 99397, upload-time = "2026-04-17T18:39:49.221Z" },
 ]
 
 [[package]]
@@ -111,20 +111,20 @@ wheels = [
 
 [[package]]
 name = "packaging"
-version = "25.0"
+version = "26.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a1/d4/1fc4078c65507b51b96ca8f8c3ba19e6a61c8253c72794544580a7b6c24d/packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f", size = 165727, upload-time = "2025-04-19T11:48:59.673Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/20/12/38679034af332785aac8774540895e234f4d07f7545804097de4b666afd8/packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484", size = 66469, upload-time = "2025-04-19T11:48:57.875Z" },
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
 ]
 
 [[package]]
 name = "platformdirs"
-version = "4.5.1"
+version = "4.10.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/cf/86/0248f086a84f01b37aaec0fa567b397df1a119f73c16f6c7a9aac73ea309/platformdirs-4.5.1.tar.gz", hash = "sha256:61d5cdcc6065745cdd94f0f878977f8de9437be93de97c1c12f853c9c0cdcbda", size = 21715, upload-time = "2025-12-05T13:52:58.638Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/47/e4501f49c178ae1d9f4a75073fda4204f52647993f075a9db4d14930e0c5/platformdirs-4.10.0.tar.gz", hash = "sha256:31e761a6a0ca04faf7353ea759bdba55652be214725111e5aac52dfa29d4bef7", size = 31224, upload-time = "2026-05-28T03:32:53.587Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cb/28/3bfe2fa5a7b9c46fe7e13c97bda14c895fb10fa2ebf1d0abb90e0cea7ee1/platformdirs-4.5.1-py3-none-any.whl", hash = "sha256:d03afa3963c806a9bed9d5125c8f4cb2fdaf74a55ab60e5d59b3fde758104d31", size = 18731, upload-time = "2025-12-05T13:52:56.823Z" },
+    { url = "https://files.pythonhosted.org/packages/81/e6/cd9575ac904136b3cbf7aa7ee819ef86eedb7274e46f230e94ea4342e729/platformdirs-4.10.0-py3-none-any.whl", hash = "sha256:fb516cdb12eb0d857d0cd85a7c57cea4d060bee4578d6cf5a14dfdf8cbf8784a", size = 22743, upload-time = "2026-05-28T03:32:52.175Z" },
 ]
 
 [[package]]
@@ -199,6 +199,19 @@ wheels = [
 ]
 
 [[package]]
+name = "python-discovery"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "filelock" },
+    { name = "platformdirs" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a6/12/38c1a0b1e64806780c9563e3fc9f6e472251839662587cfbe9bfaf2ae10a/python_discovery-1.4.0.tar.gz", hash = "sha256:eb8bc7daad3c226c147e45bb4e970a1feb1bf4048ee178e6db59e197b8010ce3", size = 68455, upload-time = "2026-05-28T01:15:37.639Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/8d/3d316429f65029532bb1e28ff77b797d86b5ac3915bb44ca4e19aa283d43/python_discovery-1.4.0-py3-none-any.whl", hash = "sha256:26ed78d703e234879a66244c7d4114563fb13ec5cd30a2d1357e5fb4850782da", size = 33217, upload-time = "2026-05-28T01:15:36.573Z" },
+]
+
+[[package]]
 name = "pyyaml"
 version = "6.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -255,62 +268,11 @@ wheels = [
 
 [[package]]
 name = "ruamel-yaml"
-version = "0.18.17"
+version = "0.19.1"
 source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "ruamel-yaml-clib", marker = "python_full_version < '3.15' and platform_python_implementation == 'CPython'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/3a/2b/7a1f1ebcd6b3f14febdc003e658778d81e76b40df2267904ee6b13f0c5c6/ruamel_yaml-0.18.17.tar.gz", hash = "sha256:9091cd6e2d93a3a4b157ddb8fabf348c3de7f1fb1381346d985b6b247dcd8d3c", size = 149602, upload-time = "2025-12-17T20:02:55.757Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/3b/ebda527b56beb90cb7652cb1c7e4f91f48649fbcd8d2eb2fb6e77cd3329b/ruamel_yaml-0.19.1.tar.gz", hash = "sha256:53eb66cd27849eff968ebf8f0bf61f46cdac2da1d1f3576dd4ccee9b25c31993", size = 142709, upload-time = "2026-01-02T16:50:31.84Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/af/fe/b6045c782f1fd1ae317d2a6ca1884857ce5c20f59befe6ab25a8603c43a7/ruamel_yaml-0.18.17-py3-none-any.whl", hash = "sha256:9c8ba9eb3e793efdf924b60d521820869d5bf0cb9c6f1b82d82de8295e290b9d", size = 121594, upload-time = "2025-12-17T20:02:07.657Z" },
-]
-
-[[package]]
-name = "ruamel-yaml-clib"
-version = "0.2.15"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ea/97/60fda20e2fb54b83a61ae14648b0817c8f5d84a3821e40bfbdae1437026a/ruamel_yaml_clib-0.2.15.tar.gz", hash = "sha256:46e4cc8c43ef6a94885f72512094e482114a8a706d3c555a34ed4b0d20200600", size = 225794, upload-time = "2025-11-16T16:12:59.761Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/2c/80/8ce7b9af532aa94dd83360f01ce4716264db73de6bc8efd22c32341f6658/ruamel_yaml_clib-0.2.15-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:c583229f336682b7212a43d2fa32c30e643d3076178fb9f7a6a14dde85a2d8bd", size = 147998, upload-time = "2025-11-16T16:13:13.241Z" },
-    { url = "https://files.pythonhosted.org/packages/53/09/de9d3f6b6701ced5f276d082ad0f980edf08ca67114523d1b9264cd5e2e0/ruamel_yaml_clib-0.2.15-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:56ea19c157ed8c74b6be51b5fa1c3aff6e289a041575f0556f66e5fb848bb137", size = 132743, upload-time = "2025-11-16T16:13:14.265Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/f7/73a9b517571e214fe5c246698ff3ed232f1ef863c8ae1667486625ec688a/ruamel_yaml_clib-0.2.15-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:5fea0932358e18293407feb921d4f4457db837b67ec1837f87074667449f9401", size = 731459, upload-time = "2025-11-16T20:22:44.338Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/a2/0dc0013169800f1c331a6f55b1282c1f4492a6d32660a0cf7b89e6684919/ruamel_yaml_clib-0.2.15-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ef71831bd61fbdb7aa0399d5c4da06bea37107ab5c79ff884cc07f2450910262", size = 749289, upload-time = "2025-11-16T16:13:15.633Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/ed/3fb20a1a96b8dc645d88c4072df481fe06e0289e4d528ebbdcc044ebc8b3/ruamel_yaml_clib-0.2.15-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:617d35dc765715fa86f8c3ccdae1e4229055832c452d4ec20856136acc75053f", size = 777630, upload-time = "2025-11-16T16:13:16.898Z" },
-    { url = "https://files.pythonhosted.org/packages/60/50/6842f4628bc98b7aa4733ab2378346e1441e150935ad3b9f3c3c429d9408/ruamel_yaml_clib-0.2.15-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1b45498cc81a4724a2d42273d6cfc243c0547ad7c6b87b4f774cb7bcc131c98d", size = 744368, upload-time = "2025-11-16T16:13:18.117Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/b0/128ae8e19a7d794c2e36130a72b3bb650ce1dd13fb7def6cf10656437dcf/ruamel_yaml_clib-0.2.15-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:def5663361f6771b18646620fca12968aae730132e104688766cf8a3b1d65922", size = 745233, upload-time = "2025-11-16T20:22:45.833Z" },
-    { url = "https://files.pythonhosted.org/packages/75/05/91130633602d6ba7ce3e07f8fc865b40d2a09efd4751c740df89eed5caf9/ruamel_yaml_clib-0.2.15-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:014181cdec565c8745b7cbc4de3bf2cc8ced05183d986e6d1200168e5bb59490", size = 770963, upload-time = "2025-11-16T16:13:19.344Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/4b/fd4542e7f33d7d1bc64cc9ac9ba574ce8cf145569d21f5f20133336cdc8c/ruamel_yaml_clib-0.2.15-cp311-cp311-win32.whl", hash = "sha256:d290eda8f6ada19e1771b54e5706b8f9807e6bb08e873900d5ba114ced13e02c", size = 102640, upload-time = "2025-11-16T16:13:20.498Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/eb/00ff6032c19c7537371e3119287999570867a0eafb0154fccc80e74bf57a/ruamel_yaml_clib-0.2.15-cp311-cp311-win_amd64.whl", hash = "sha256:bdc06ad71173b915167702f55d0f3f027fc61abd975bd308a0968c02db4a4c3e", size = 121996, upload-time = "2025-11-16T16:13:21.855Z" },
-    { url = "https://files.pythonhosted.org/packages/72/4b/5fde11a0722d676e469d3d6f78c6a17591b9c7e0072ca359801c4bd17eee/ruamel_yaml_clib-0.2.15-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:cb15a2e2a90c8475df45c0949793af1ff413acfb0a716b8b94e488ea95ce7cff", size = 149088, upload-time = "2025-11-16T16:13:22.836Z" },
-    { url = "https://files.pythonhosted.org/packages/85/82/4d08ac65ecf0ef3b046421985e66301a242804eb9a62c93ca3437dc94ee0/ruamel_yaml_clib-0.2.15-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:64da03cbe93c1e91af133f5bec37fd24d0d4ba2418eaf970d7166b0a26a148a2", size = 134553, upload-time = "2025-11-16T16:13:24.151Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/cb/22366d68b280e281a932403b76da7a988108287adff2bfa5ce881200107a/ruamel_yaml_clib-0.2.15-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:f6d3655e95a80325b84c4e14c080b2470fe4f33b6846f288379ce36154993fb1", size = 737468, upload-time = "2025-11-16T20:22:47.335Z" },
-    { url = "https://files.pythonhosted.org/packages/71/73/81230babf8c9e33770d43ed9056f603f6f5f9665aea4177a2c30ae48e3f3/ruamel_yaml_clib-0.2.15-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:71845d377c7a47afc6592aacfea738cc8a7e876d586dfba814501d8c53c1ba60", size = 753349, upload-time = "2025-11-16T16:13:26.269Z" },
-    { url = "https://files.pythonhosted.org/packages/61/62/150c841f24cda9e30f588ef396ed83f64cfdc13b92d2f925bb96df337ba9/ruamel_yaml_clib-0.2.15-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:11e5499db1ccbc7f4b41f0565e4f799d863ea720e01d3e99fa0b7b5fcd7802c9", size = 788211, upload-time = "2025-11-16T16:13:27.441Z" },
-    { url = "https://files.pythonhosted.org/packages/30/93/e79bd9cbecc3267499d9ead919bd61f7ddf55d793fb5ef2b1d7d92444f35/ruamel_yaml_clib-0.2.15-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:4b293a37dc97e2b1e8a1aec62792d1e52027087c8eea4fc7b5abd2bdafdd6642", size = 743203, upload-time = "2025-11-16T16:13:28.671Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/06/1eb640065c3a27ce92d76157f8efddb184bd484ed2639b712396a20d6dce/ruamel_yaml_clib-0.2.15-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:512571ad41bba04eac7268fe33f7f4742210ca26a81fe0c75357fa682636c690", size = 747292, upload-time = "2025-11-16T20:22:48.584Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/21/ee353e882350beab65fcc47a91b6bdc512cace4358ee327af2962892ff16/ruamel_yaml_clib-0.2.15-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e5e9f630c73a490b758bf14d859a39f375e6999aea5ddd2e2e9da89b9953486a", size = 771624, upload-time = "2025-11-16T16:13:29.853Z" },
-    { url = "https://files.pythonhosted.org/packages/57/34/cc1b94057aa867c963ecf9ea92ac59198ec2ee3a8d22a126af0b4d4be712/ruamel_yaml_clib-0.2.15-cp312-cp312-win32.whl", hash = "sha256:f4421ab780c37210a07d138e56dd4b51f8642187cdfb433eb687fe8c11de0144", size = 100342, upload-time = "2025-11-16T16:13:31.067Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/e5/8925a4208f131b218f9a7e459c0d6fcac8324ae35da269cb437894576366/ruamel_yaml_clib-0.2.15-cp312-cp312-win_amd64.whl", hash = "sha256:2b216904750889133d9222b7b873c199d48ecbb12912aca78970f84a5aa1a4bc", size = 119013, upload-time = "2025-11-16T16:13:32.164Z" },
-    { url = "https://files.pythonhosted.org/packages/17/5e/2f970ce4c573dc30c2f95825f2691c96d55560268ddc67603dc6ea2dd08e/ruamel_yaml_clib-0.2.15-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:4dcec721fddbb62e60c2801ba08c87010bd6b700054a09998c4d09c08147b8fb", size = 147450, upload-time = "2025-11-16T16:13:33.542Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/03/a1baa5b94f71383913f21b96172fb3a2eb5576a4637729adbf7cd9f797f8/ruamel_yaml_clib-0.2.15-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:65f48245279f9bb301d1276f9679b82e4c080a1ae25e679f682ac62446fac471", size = 133139, upload-time = "2025-11-16T16:13:34.587Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/19/40d676802390f85784235a05788fd28940923382e3f8b943d25febbb98b7/ruamel_yaml_clib-0.2.15-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:46895c17ead5e22bea5e576f1db7e41cb273e8d062c04a6a49013d9f60996c25", size = 731474, upload-time = "2025-11-16T20:22:49.934Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/bb/6ef5abfa43b48dd55c30d53e997f8f978722f02add61efba31380d73e42e/ruamel_yaml_clib-0.2.15-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3eb199178b08956e5be6288ee0b05b2fb0b5c1f309725ad25d9c6ea7e27f962a", size = 748047, upload-time = "2025-11-16T16:13:35.633Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/5d/e4f84c9c448613e12bd62e90b23aa127ea4c46b697f3d760acc32cb94f25/ruamel_yaml_clib-0.2.15-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4d1032919280ebc04a80e4fb1e93f7a738129857eaec9448310e638c8bccefcf", size = 782129, upload-time = "2025-11-16T16:13:36.781Z" },
-    { url = "https://files.pythonhosted.org/packages/de/4b/e98086e88f76c00c88a6bcf15eae27a1454f661a9eb72b111e6bbb69024d/ruamel_yaml_clib-0.2.15-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:ab0df0648d86a7ecbd9c632e8f8d6b21bb21b5fc9d9e095c796cacf32a728d2d", size = 736848, upload-time = "2025-11-16T16:13:37.952Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/5c/5964fcd1fd9acc53b7a3a5d9a05ea4f95ead9495d980003a557deb9769c7/ruamel_yaml_clib-0.2.15-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:331fb180858dd8534f0e61aa243b944f25e73a4dae9962bd44c46d1761126bbf", size = 741630, upload-time = "2025-11-16T20:22:51.718Z" },
-    { url = "https://files.pythonhosted.org/packages/07/1e/99660f5a30fceb58494598e7d15df883a07292346ef5696f0c0ae5dee8c6/ruamel_yaml_clib-0.2.15-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:fd4c928ddf6bce586285daa6d90680b9c291cfd045fc40aad34e445d57b1bf51", size = 766619, upload-time = "2025-11-16T16:13:39.178Z" },
-    { url = "https://files.pythonhosted.org/packages/36/2f/fa0344a9327b58b54970e56a27b32416ffbcfe4dcc0700605516708579b2/ruamel_yaml_clib-0.2.15-cp313-cp313-win32.whl", hash = "sha256:bf0846d629e160223805db9fe8cc7aec16aaa11a07310c50c8c7164efa440aec", size = 100171, upload-time = "2025-11-16T16:13:40.456Z" },
-    { url = "https://files.pythonhosted.org/packages/06/c4/c124fbcef0684fcf3c9b72374c2a8c35c94464d8694c50f37eef27f5a145/ruamel_yaml_clib-0.2.15-cp313-cp313-win_amd64.whl", hash = "sha256:45702dfbea1420ba3450bb3dd9a80b33f0badd57539c6aac09f42584303e0db6", size = 118845, upload-time = "2025-11-16T16:13:41.481Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/bd/ab8459c8bb759c14a146990bf07f632c1cbec0910d4853feeee4be2ab8bb/ruamel_yaml_clib-0.2.15-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:753faf20b3a5906faf1fc50e4ddb8c074cb9b251e00b14c18b28492f933ac8ef", size = 147248, upload-time = "2025-11-16T16:13:42.872Z" },
-    { url = "https://files.pythonhosted.org/packages/69/f2/c4cec0a30f1955510fde498aac451d2e52b24afdbcb00204d3a951b772c3/ruamel_yaml_clib-0.2.15-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:480894aee0b29752560a9de46c0e5f84a82602f2bc5c6cde8db9a345319acfdf", size = 133764, upload-time = "2025-11-16T16:13:43.932Z" },
-    { url = "https://files.pythonhosted.org/packages/82/c7/2480d062281385a2ea4f7cc9476712446e0c548cd74090bff92b4b49e898/ruamel_yaml_clib-0.2.15-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:4d3b58ab2454b4747442ac76fab66739c72b1e2bb9bd173d7694b9f9dbc9c000", size = 730537, upload-time = "2025-11-16T20:22:52.918Z" },
-    { url = "https://files.pythonhosted.org/packages/75/08/e365ee305367559f57ba6179d836ecc3d31c7d3fdff2a40ebf6c32823a1f/ruamel_yaml_clib-0.2.15-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bfd309b316228acecfa30670c3887dcedf9b7a44ea39e2101e75d2654522acd4", size = 746944, upload-time = "2025-11-16T16:13:45.338Z" },
-    { url = "https://files.pythonhosted.org/packages/a1/5c/8b56b08db91e569d0a4fbfa3e492ed2026081bdd7e892f63ba1c88a2f548/ruamel_yaml_clib-0.2.15-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2812ff359ec1f30129b62372e5f22a52936fac13d5d21e70373dbca5d64bb97c", size = 778249, upload-time = "2025-11-16T16:13:46.871Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/1d/70dbda370bd0e1a92942754c873bd28f513da6198127d1736fa98bb2a16f/ruamel_yaml_clib-0.2.15-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7e74ea87307303ba91073b63e67f2c667e93f05a8c63079ee5b7a5c8d0d7b043", size = 737140, upload-time = "2025-11-16T16:13:48.349Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/87/822d95874216922e1120afb9d3fafa795a18fdd0c444f5c4c382f6dac761/ruamel_yaml_clib-0.2.15-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:713cd68af9dfbe0bb588e144a61aad8dcc00ef92a82d2e87183ca662d242f524", size = 741070, upload-time = "2025-11-16T20:22:54.151Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/17/4e01a602693b572149f92c983c1f25bd608df02c3f5cf50fd1f94e124a59/ruamel_yaml_clib-0.2.15-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:542d77b72786a35563f97069b9379ce762944e67055bea293480f7734b2c7e5e", size = 765882, upload-time = "2025-11-16T16:13:49.526Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/17/7999399081d39ebb79e807314de6b611e1d1374458924eb2a489c01fc5ad/ruamel_yaml_clib-0.2.15-cp314-cp314-win32.whl", hash = "sha256:424ead8cef3939d690c4b5c85ef5b52155a231ff8b252961b6516ed7cf05f6aa", size = 102567, upload-time = "2025-11-16T16:13:50.78Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/67/be582a7370fdc9e6846c5be4888a530dcadd055eef5b932e0e85c33c7d73/ruamel_yaml_clib-0.2.15-cp314-cp314-win_amd64.whl", hash = "sha256:ac9b8d5fa4bb7fd2917ab5027f60d4234345fd366fe39aa711d5dca090aa1467", size = 122847, upload-time = "2025-11-16T16:13:51.807Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/0c/51f6841f1d84f404f92463fc2b1ba0da357ca1e3db6b7fbda26956c3b82a/ruamel_yaml-0.19.1-py3-none-any.whl", hash = "sha256:27592957fedf6e0b62f281e96effd28043345e0e66001f97683aa9a40c667c93", size = 118102, upload-time = "2026-01-02T16:50:29.201Z" },
 ]
 
 [[package]]
@@ -365,14 +327,15 @@ wheels = [
 
 [[package]]
 name = "virtualenv"
-version = "20.36.1"
+version = "21.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "distlib" },
     { name = "filelock" },
     { name = "platformdirs" },
+    { name = "python-discovery" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/aa/a3/4d310fa5f00863544e1d0f4de93bddec248499ccf97d4791bc3122c9d4f3/virtualenv-20.36.1.tar.gz", hash = "sha256:8befb5c81842c641f8ee658481e42641c68b5eab3521d8e092d18320902466ba", size = 6032239, upload-time = "2026-01-09T18:21:01.296Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e1/0d/4e93c8e6d1001a75763f87d8f5ecda8ebc7f4aa2153dddfaf4ae8892821a/virtualenv-21.4.2.tar.gz", hash = "sha256:38e6ee0a555615c0ea9da2ac7e9998fe8dc3b911dd33ad8eaad2020957653b0c", size = 7613326, upload-time = "2026-05-31T17:01:22.827Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6a/2a/dc2228b2888f51192c7dc766106cd475f1b768c10caaf9727659726f7391/virtualenv-20.36.1-py3-none-any.whl", hash = "sha256:575a8d6b124ef88f6f51d56d656132389f961062a9177016a50e4f507bbcc19f", size = 6008258, upload-time = "2026-01-09T18:20:59.425Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/c4/557dc082be035381b85fdb2b74e21d3d21b57750b74f2b47a32f3a639ff9/virtualenv-21.4.2-py3-none-any.whl", hash = "sha256:854210ca524a1a4d0d744734f4acbc721c3ffe163b85bbf5d56d14d5ae2f0fae", size = 7594079, upload-time = "2026-05-31T17:01:20.735Z" },
 ]


### PR DESCRIPTION
## Summary

Maintenance pass for the 1.0.39 release. Bumps dependencies and the version, then aligns the dev toolchain, sharpens the ruff/ty rulesets to best-practice, drops the now-unsupported Python 3.11, and removes dead config.

The headline fix is **tool version drift**: `.pre-commit-config.yaml` pinned `ruff` at v0.11.5 while the dev environment had 0.15.15. Because `make check` lints only via pre-commit, the newer ruff's findings were invisible to CI — masking lint errors and a silently-disabled import sorter.

## Changes

**Dependencies & version** (pre-existing commits on branch)
- Bump dependencies and version to 1.0.39.

**Tooling alignment**
- Bump pre-commit `ruff` v0.11.5 → v0.15.15 to match the dev environment.
- Tighten dev pins: `ruff>=0.15.0`, `ty>=0.0.42`.
- Migrate leftover mypy-style `# type: ignore[code]` comments to ty-native `# ty: ignore[rule]` (ty was not honoring the mypy codes, so the suppressions were ineffective).

**Drop Python 3.11 → minimum 3.12**
- `requires-python`, ruff `target-version`, ty `python-version`, and docs updated.
- CI test matrix → 3.12 + 3.13 (removed a stale, inaccurate "numpy" comment — the project has no numpy dependency).

**Sharpen ruff**
- Remove dead `[tool.isort]` section; enable ruff import sorting (`force-single-line`, dropped the `I001` ignore).
- Add `SIM`, `PT`, `RET`, `G`, `LOG` rule families and fix all resulting findings:
  - 43 logging f-strings → lazy `%`-formatting (G004)
  - example uses a module logger instead of the root logger (LOG015)
  - collapsed nested `if`/`with`, `contextlib.suppress`, context-managed temp file (SIM)
  - moved lazy test imports to module top (PLC0415)

**Sharpen ty**
- `error-on-warning = true` (config is clean).

**Cleanup**
- Remove dead `[tool.coverage]` config (coverage was never actually collected; `fail_under = 2` was misleading).

## Compatibility note
Dropping Python 3.11 is a compatibility change for any 3.11 consumers.

## Verification
- `make check` passes (ruff 0.15.15 + ty with `error-on-warning = true`).
- `uv run ruff check .` reports 0 errors — confirms local/CI lint parity.
- `make test` — all 42 tests pass.